### PR TITLE
Feature log output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,11 +5,11 @@
 *.iml
 
 ## Directory-based project format:
-#.idea/
+.idea/
 # if you remove the above rule, at least ignore the following:
 
 # User-specific stuff:
-.idea/workspace.xml
+#.idea/workspace.xml
 .idea/tasks.xml
 .idea/dictionaries
 

--- a/rundeck-agent/src/main/kotlin/com/hadihariri/teamcity/plugins/rundeck/agent/RunDeckAPI.kt
+++ b/rundeck-agent/src/main/kotlin/com/hadihariri/teamcity/plugins/rundeck/agent/RunDeckAPI.kt
@@ -78,8 +78,8 @@ public class RunDeckAPI(val host: String, val authToken: String) {
                         element.getChild("hasFailedNodes").text == "true",
                         element.getChild("execState").text,
                         element.getChild("execDuration").text.toLong(),
-                        element.getChild("offset").text.toLong(),
-                        element.getChild("lastModified").text.toLong(),
+                        element.getChild("offset")?.text?.toLong() ?: 0L,
+                        element.getChild("lastModified")?.text?.toLong() ?: 0L,
                         entries,
                         data
                 )

--- a/rundeck-agent/src/main/kotlin/com/hadihariri/teamcity/plugins/rundeck/agent/RunDeckAPI.kt
+++ b/rundeck-agent/src/main/kotlin/com/hadihariri/teamcity/plugins/rundeck/agent/RunDeckAPI.kt
@@ -3,8 +3,10 @@ package com.hadihariri.teamcity.plugins.rundeck.agent
 import com.squareup.okhttp.OkHttpClient
 import com.squareup.okhttp.Request
 import jetbrains.buildServer.util.FileUtil
+import org.jdom.Element
 import java.io.StringReader
 import java.net.URLEncoder
+import java.util.*
 
 /**
  * Created by hadihariri on 05/10/15.
@@ -17,7 +19,7 @@ public class RunDeckAPI(val host: String, val authToken: String) {
         return "$host/api/$apiVersion/$action?$query&authtoken=$authToken"
     }
 
-    fun  executeJob(jobId: String, jobOptions: String = "", filters: String = ""): RunDeckExecuteJobResponse {
+    fun executeJob(jobId: String, jobOptions: String = "", filters: String = ""): RunDeckExecuteJobResponse {
         var query = ""
         if (jobOptions != "" && jobOptions != "null") {
             query = "argString=${URLEncoder.encode(jobOptions, "utf-8")}"
@@ -49,25 +51,38 @@ public class RunDeckAPI(val host: String, val authToken: String) {
         }
     }
 
-    // TODO: Need to parse entries
-    fun jobStatus(executionId: String): RunDeckJobStatusResponse {
+    fun jobStatus(executionId: String, offset: Long = 0, lastModified: Long = 0): RunDeckJobStatusResponse {
         val client = OkHttpClient()
         val request = Request.Builder()
-                .url(createRequestUrl("execution/$executionId/output", ""))
+                .url(createRequestUrl("execution/$executionId/output", "offset=$offset&lastmod=$lastModified"))
                 .build()
         val response = client.newCall(request).execute()
         when (response.code()) {
             200 -> {
                 val data = response.body().string()
                 val element = FileUtil.parseDocument(StringReader(data), false)
+
+                val entries = ArrayList<String>()
+                for (entry in element.getChild("entries").children) {
+                    val elt = entry as Element
+                    val node = elt.getAttribute("node").value
+                    val time = elt.getAttribute("time").value
+                    val level = elt.getAttribute("level").value
+                    val log = elt.getAttribute("log").value
+                    entries.add("%s [%s] %-8s %s".format(time, node, level, log))
+                }
+
                 return RunDeckJobStatusResponse(200,
                         element.getChild("completed").text == "true",
                         element.getChild("execCompleted").text == "true",
                         element.getChild("hasFailedNodes").text == "true",
                         element.getChild("execState").text,
                         element.getChild("execDuration").text.toLong(),
+                        element.getChild("offset").text.toLong(),
+                        element.getChild("lastModified").text.toLong(),
+                        entries,
                         data
-                        )
+                )
             }
             else -> {
                 return RunDeckJobStatusResponse(response.code(), rawData = response.body().string())

--- a/rundeck-agent/src/main/kotlin/com/hadihariri/teamcity/plugins/rundeck/agent/RunDeckAPIResponse.kt
+++ b/rundeck-agent/src/main/kotlin/com/hadihariri/teamcity/plugins/rundeck/agent/RunDeckAPIResponse.kt
@@ -1,14 +1,34 @@
 package com.hadihariri.teamcity.plugins.rundeck.agent
 
-import jetbrains.buildServer.util.PropertiesUtil
-import java.io.File
+import java.util.*
 
 /**
  * Created by hadihariri on 05/10/15.
  */
 data class RunDeckExecuteJobResponse(val code: Int, val result: String)
 
-data class RunDeckJobStatusResponse(val code: Int, val completed: Boolean = false, val execCompleted: Boolean = false, val hasFailedNodes: Boolean = false, val execState: String = "failed", val execDuration: Long = 0, val rawData: String = "")
-data class RunDeckOptions(val url: String, val authToken: String, val includeOutput: Boolean, val failBuild: Boolean, val waitFinish: Boolean, val jobId: String, val jobOptions: String, val filters: String)
+data class RunDeckJobStatusResponse(
+        val code: Int,
+        val completed: Boolean = false,
+        val execCompleted: Boolean = false,
+        val hasFailedNodes: Boolean = false,
+        val execState: String = "failed",
+        val execDuration: Long = 0,
+        val offset: Long = 0,
+        val lastModified: Long = 0,
+        val entries: List<String> = ArrayList(),
+        val rawData: String = ""
+)
+
+data class RunDeckOptions(
+        val url: String,
+        val authToken: String,
+        val includeOutput: Boolean,
+        val failBuild: Boolean,
+        val waitFinish: Boolean,
+        val jobId: String,
+        val jobOptions: String,
+        val filters: String
+)
 
 


### PR DESCRIPTION
**Summary**
Retrieve entries in _RunDeckAPI#jobStatus()_ and return them with _RunDeckJobStatusResponse_.
Print the entries in _RunDeck_, get the offset and lastModified field and make a new _RunDeckAPI#jobStatus()_ to get next lines until the execution is complete.

**Others**
Add all the .dea directory in _.gitignore_ to avoid idea specific files to be pushed
Change the _Thread.sleep_ from 5000*counter to 5000 to have a better log output flow

**Warning**
When _jobStatus_ is called just before the job execution, some xml fields may be absent. We have to check nullity of _element.getChild("offset")_ and _element.getChild("lastModified")_

**TODO**
Add conversion pattern field to rundeck-server to customize the log output format.

_Tested with internal RunDeck instance_
_Implementation reference : http://rundeck.org/2.5.2/jp/api/index.html#tailing-output_
